### PR TITLE
fix: replace CodeQL autobuild with explicit dotnet build, fix CODEOWNERS AB#1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,25 @@
 # CODEOWNERS — require review from specific teams for paths
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Default — all changes need platform team review
-*                           @your-org/platform-team
+# Default — all changes need owner review
+*                           @ncheruvu-MSFT
 
-# Infrastructure — requires infra/security review
-/infra/                     @your-org/infra-team @your-org/security-team
+# Infrastructure — requires owner review
+/infra/                     @ncheruvu-MSFT
 
-# CI/CD pipelines — requires DevOps review
-/.github/workflows/         @your-org/devops-team @your-org/security-team
-/.github/dependabot.yml     @your-org/devops-team
+# CI/CD pipelines — requires owner review
+/.github/workflows/         @ncheruvu-MSFT
+/.github/dependabot.yml     @ncheruvu-MSFT
 
 # Security policy
-/SECURITY.md                @your-org/security-team
+/SECURITY.md                @ncheruvu-MSFT
 
 # C# applications
-/src/FunctionApp/           @your-org/backend-team
-/src/ContainerApp/          @your-org/backend-team
+/src/FunctionApp/           @ncheruvu-MSFT
+/src/ContainerApp/          @ncheruvu-MSFT
 
 # Python API
-/src/PythonApi/             @your-org/api-team
+/src/PythonApi/             @ncheruvu-MSFT
 
 # Tests — respective owners
-/tests/                     @your-org/backend-team @your-org/api-team
+/tests/                     @ncheruvu-MSFT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,8 @@ jobs:
         with:
           languages: csharp, python
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Build for CodeQL
+        run: dotnet build SsdlcDemo.sln --configuration Release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,18 @@ jobs:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
-      - name: Autobuild
+      - name: Setup .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build (.NET)
+        if: matrix.language == 'csharp'
+        run: dotnet build SsdlcDemo.sln --configuration Release
+
+      - name: Autobuild (Python)
+        if: matrix.language == 'python'
         uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Description
Fixes CI Security Scanning (SSDLC) job failure caused by CodeQL autobuild unable to detect C# build in multi-language (csharp+python) mode.

## Changes
- **ci.yml**: Replace utobuild with explicit dotnet build SsdlcDemo.sln --configuration Release`n- **codeql.yml**: Split autobuild into conditional steps (dotnet build for C#, autobuild for Python)
- **CODEOWNERS**: Replace placeholder teams with @ncheruvu-MSFT

## Type of Change
- [x] Bug fix

## SSDLC Checklist
- [x] Code follows security coding standards
- [x] No secrets or credentials are hardcoded
- [x] Security scanning passes
AB#1