### PR TITLE
feat: add /api/version endpoint to Function App AB#30

### DIFF
--- a/src/FunctionApp/Functions/VersionFunction.cs
+++ b/src/FunctionApp/Functions/VersionFunction.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace HelloWorld.Functions;
+
+/// <summary>
+/// HTTP-triggered Azure Function — returns build metadata for deployment verification.
+/// </summary>
+public class VersionFunction
+{
+    private readonly ILogger<VersionFunction> _logger;
+
+    public VersionFunction(ILogger<VersionFunction> logger)
+    {
+        _logger = logger;
+    }
+
+    [Function("Version")]
+    public IActionResult Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "version")] HttpRequest req)
+    {
+        _logger.LogInformation("Version endpoint requested.");
+
+        var assembly = Assembly.GetExecutingAssembly();
+        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "unknown";
+        var commitSha = Environment.GetEnvironmentVariable("COMMIT_SHA") ?? "local";
+        var buildDate = Environment.GetEnvironmentVariable("BUILD_DATE") ?? DateTimeOffset.UtcNow.ToString("o");
+
+        return new OkObjectResult(new
+        {
+            Version = version,
+            CommitSha = commitSha,
+            BuildDate = buildDate,
+            Timestamp = DateTimeOffset.UtcNow
+        });
+    }
+}

--- a/tests/FunctionApp.Tests/VersionFunctionTests.cs
+++ b/tests/FunctionApp.Tests/VersionFunctionTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using HelloWorld.Functions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace HelloWorld.Functions.Tests;
+
+public class VersionFunctionTests
+{
+    private readonly VersionFunction _sut;
+    private readonly Mock<ILogger<VersionFunction>> _logger;
+
+    public VersionFunctionTests()
+    {
+        _logger = new Mock<ILogger<VersionFunction>>();
+        _sut = new VersionFunction(_logger.Object);
+    }
+
+    [Fact]
+    public void Run_ReturnsOkWithVersionInfo()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        // Act
+        var result = _sut.Run(context.Request) as OkObjectResult;
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.StatusCode.Should().Be(200);
+
+        var value = result.Value;
+        value.Should().NotBeNull();
+
+        var versionProp = value!.GetType().GetProperty("Version");
+        versionProp.Should().NotBeNull();
+        versionProp!.GetValue(value).Should().NotBeNull();
+
+        var commitShaProp = value.GetType().GetProperty("CommitSha");
+        commitShaProp.Should().NotBeNull();
+
+        var buildDateProp = value.GetType().GetProperty("BuildDate");
+        buildDateProp.Should().NotBeNull();
+
+        var timestampProp = value.GetType().GetProperty("Timestamp");
+        timestampProp.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Run_WhenCommitShaEnvSet_ReturnsIt()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        Environment.SetEnvironmentVariable("COMMIT_SHA", "abc123def");
+
+        try
+        {
+            // Act
+            var result = _sut.Run(context.Request) as OkObjectResult;
+
+            // Assert
+            result.Should().NotBeNull();
+            var value = result!.Value;
+            var commitShaProp = value!.GetType().GetProperty("CommitSha");
+            commitShaProp!.GetValue(value).Should().Be("abc123def");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("COMMIT_SHA", null);
+        }
+    }
+
+    [Fact]
+    public void Run_WhenNoCommitShaEnv_ReturnsLocal()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        Environment.SetEnvironmentVariable("COMMIT_SHA", null);
+
+        // Act
+        var result = _sut.Run(context.Request) as OkObjectResult;
+
+        // Assert
+        result.Should().NotBeNull();
+        var value = result!.Value;
+        var commitShaProp = value!.GetType().GetProperty("CommitSha");
+        commitShaProp!.GetValue(value).Should().Be("local");
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new /api/version GET endpoint to the Azure Function App that returns build metadata:
- **Version**: Assembly informational version
- **CommitSha**: From COMMIT_SHA env var (set at deploy time)
- **BuildDate**: From BUILD_DATE env var

## ADO Work Items
- Resolves [AB#30](https://dev.azure.com/ncheruvu0468/78663987-57a0-4f1d-b5a0-8d9ac2417cc1/_workitems/edit/30) — Implement VersionFunction.cs with unit tests
- Related [AB#29](https://dev.azure.com/ncheruvu0468/78663987-57a0-4f1d-b5a0-8d9ac2417cc1/_workitems/edit/29) — Add /api/version endpoint to Function App

## Changes
- src/FunctionApp/Functions/VersionFunction.cs — New HTTP GET function at /api/version`n- 	ests/FunctionApp.Tests/VersionFunctionTests.cs — 3 xUnit tests with FluentAssertions

## Testing
- [x] 20 total tests pass (13 FunctionApp + 7 ContainerApp)
- [x] Build succeeds with 0 warnings
- [x] Follows existing HelloWorldFunction.cs patterns

## Security Checklist
- [x] No hardcoded secrets
- [x] No sensitive data logged
- [x] Input validation (env vars default to safe values)
- [x] Anonymous auth level (version info is non-sensitive)