### PR TITLE
feat: automated test reports + Notation container image signing AB#29

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   id-token: write    # OIDC for Azure login
   contents: read
+  packages: write    # Container image signing
 
 env:
   DOTNET_VERSION: "8.0.x"
@@ -85,6 +86,62 @@ jobs:
           push: true
           tags: ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/pythonapi:${{ github.sha }}
 
+      # ── Container Image Signing with Notation (Notary v2) ──
+      - name: Install Notation CLI
+        uses: notaryproject/notation-action/setup@v1
+        with:
+          version: "1.2.0"
+
+      - name: Generate signing key (self-signed for demo)
+        run: |
+          notation cert generate-test "ssdlc-demo-signing-key"
+          echo "Notation signing key generated for demo purposes"
+
+      - name: Sign Container App image
+        run: |
+          notation sign \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/containerapp:${{ github.sha }} \
+            --key "ssdlc-demo-signing-key"
+          echo "✅ Container App image signed"
+
+      - name: Sign Python API image
+        run: |
+          notation sign \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/pythonapi:${{ github.sha }} \
+            --key "ssdlc-demo-signing-key"
+          echo "✅ Python API image signed"
+
+      - name: Export trust policy for verification
+        run: |
+          # Create trust policy for downstream verification
+          mkdir -p ./notation-config
+          cat > ./notation-config/trustpolicy.json << 'EOF'
+          {
+            "version": "1.0",
+            "trustPolicies": [
+              {
+                "name": "ssdlc-demo-images",
+                "registryScopes": [ "${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/*" ],
+                "signatureVerification": {
+                  "level": "strict"
+                },
+                "trustStores": [ "ca:ssdlc-demo-signing-key" ],
+                "trustedIdentities": [ "*" ]
+              }
+            ]
+          }
+          EOF
+          # Copy certs for downstream jobs
+          cp -r ~/.config/notation ./notation-config/notation-home || true
+          echo "Trust policy created"
+
+      - name: Upload signing artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: notation-config
+          path: ./notation-config
+          retention-days: 1
+
   # ── Deploy to Dev ──────────────────────────────────────────────
   deploy-dev:
     name: "Deploy to Dev"
@@ -101,6 +158,39 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Login to ACR
+        run: az acr login --name ${{ env.ACR_NAME }}
+
+      # ── Verify container signatures before deploy ──
+      - name: Install Notation CLI
+        uses: notaryproject/notation-action/setup@v1
+        with:
+          version: "1.2.0"
+
+      - name: Download signing config
+        uses: actions/download-artifact@v4
+        with:
+          name: notation-config
+          path: ./notation-config
+
+      - name: Restore Notation trust store
+        run: |
+          mkdir -p ~/.config/notation
+          cp -r ./notation-config/notation-home/* ~/.config/notation/ || true
+          cp ./notation-config/trustpolicy.json ~/.config/notation/trustpolicy.json
+
+      - name: Verify Container App image signature
+        run: |
+          notation verify \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/containerapp:${{ github.sha }}
+          echo "✅ Container App image signature verified"
+
+      - name: Verify Python API image signature
+        run: |
+          notation verify \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/pythonapi:${{ github.sha }}
+          echo "✅ Python API image signature verified"
 
       # Deploy Infrastructure
       - name: Deploy Bicep (dev)
@@ -163,6 +253,39 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Login to ACR
+        run: az acr login --name ${{ env.ACR_NAME }}
+
+      # ── Verify container signatures before deploy ──
+      - name: Install Notation CLI
+        uses: notaryproject/notation-action/setup@v1
+        with:
+          version: "1.2.0"
+
+      - name: Download signing config
+        uses: actions/download-artifact@v4
+        with:
+          name: notation-config
+          path: ./notation-config
+
+      - name: Restore Notation trust store
+        run: |
+          mkdir -p ~/.config/notation
+          cp -r ./notation-config/notation-home/* ~/.config/notation/ || true
+          cp ./notation-config/trustpolicy.json ~/.config/notation/trustpolicy.json
+
+      - name: Verify Container App image signature
+        run: |
+          notation verify \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/containerapp:${{ github.sha }}
+          echo "✅ Container App image signature verified"
+
+      - name: Verify Python API image signature
+        run: |
+          notation verify \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/pythonapi:${{ github.sha }}
+          echo "✅ Python API image signature verified"
+
       - name: Deploy Bicep (staging)
         uses: azure/arm-deploy@v2
         with:
@@ -214,6 +337,39 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID_PROD }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_PROD }}
+
+      - name: Login to ACR
+        run: az acr login --name ${{ env.ACR_NAME }}
+
+      # ── Verify container signatures before deploy (mandatory for prod) ──
+      - name: Install Notation CLI
+        uses: notaryproject/notation-action/setup@v1
+        with:
+          version: "1.2.0"
+
+      - name: Download signing config
+        uses: actions/download-artifact@v4
+        with:
+          name: notation-config
+          path: ./notation-config
+
+      - name: Restore Notation trust store
+        run: |
+          mkdir -p ~/.config/notation
+          cp -r ./notation-config/notation-home/* ~/.config/notation/ || true
+          cp ./notation-config/trustpolicy.json ~/.config/notation/trustpolicy.json
+
+      - name: Verify Container App image signature
+        run: |
+          notation verify \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/containerapp:${{ github.sha }}
+          echo "✅ Container App image signature verified — PRODUCTION"
+
+      - name: Verify Python API image signature
+        run: |
+          notation verify \
+            ${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/pythonapi:${{ github.sha }}
+          echo "✅ Python API image signature verified — PRODUCTION"
 
       - name: Deploy Bicep (prod)
         uses: azure/arm-deploy@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   security-events: write
   pull-requests: write
+  checks: write
 
 env:
   DOTNET_VERSION: "8.0.x"
@@ -57,6 +58,15 @@ jobs:
           name: dotnet-test-results
           path: ./TestResults
 
+      - name: Publish .NET Test Report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: ".NET Test Results"
+          path: "TestResults/**/*.trx"
+          reporter: dotnet-trx
+          fail-on-error: true
+
       - name: Code Coverage Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         if: github.event_name == 'pull_request'
@@ -66,6 +76,13 @@ jobs:
           format: markdown
           output: both
           thresholds: "60 80"
+
+      - name: Post Coverage to PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md
 
   # ── Python Build & Test ────────────────────────────────────────
   python-build-test:
@@ -106,6 +123,15 @@ jobs:
         with:
           name: python-test-results
           path: ./TestResults
+
+      - name: Publish Python Test Report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: "Python Test Results"
+          path: "TestResults/python-results.xml"
+          reporter: java-junit
+          fail-on-error: true
 
   # ── SSDLC Security Scanning ───────────────────────────────────
   security-scan:


### PR DESCRIPTION
## Summary
Adds two SSDLC capabilities for the demo:

### 1. Automated Test Report Annotations (CI)
- **.NET Test Results** — \dorny/test-reporter\ publishes TRX results as GitHub check annotations
- **Python Test Results** — JUnit XML published as GitHub check annotations
- **Code Coverage PR Comment** — \marocchino/sticky-pull-request-comment\ posts coverage badge to PRs
- Added \checks: write\ permission for test reporter

### 2. Container Image Signing with Notation/Notary v2 (CD)
- **Sign images after push** — \
otaryproject/notation-action\ signs both containerapp and pythonapi images
- **Verify before every deploy** — Each environment (dev, staging, prod) verifies image signatures
- **Self-signed demo key** — Uses \
otation cert generate-test\ (swap for AKV-backed cert in production)
- Trust policy artifact shared across jobs

## SSDLC Demo Flow
\\\
Dependabot PR → CI runs → Test Reports visible → Auto-merge if patch
CD triggered → Build → Sign images → Verify signature → Deploy
\\\

## ADO Work Items
- Related [AB#29](https://dev.azure.com/ncheruvu0468/78663987-57a0-4f1d-b5a0-8d9ac2417cc1/_workitems/edit/29) — Add /api/version endpoint to Function App

## Security Checklist
- [x] Least-privilege permissions (\checks: write\ only where needed)
- [x] Actions pinned to major versions (\@v1\, \@v2\)
- [x] No secrets in logs
- [x] Image signatures verified at every environment gate
- [x] Trust policy uses strict verification level