### PR TITLE
fix: add Log Analytics workspaceId to diagnostic settings AB#29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ local.settings.json
 # Build artifacts
 artifacts/
 publish/
+infra/main.json

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -68,6 +68,7 @@ module keyVault 'modules/keyvault.bicep' = {
     tags: tags
     vnetId: networking.outputs.vnetId
     privateEndpointSubnetId: networking.outputs.privateEndpointSubnetId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 
@@ -82,6 +83,7 @@ module serviceBus 'modules/servicebus.bicep' = {
     tags: tags
     vnetId: networking.outputs.vnetId
     privateEndpointSubnetId: networking.outputs.privateEndpointSubnetId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 
@@ -111,6 +113,7 @@ module functionApp 'modules/functionapp.bicep' = {
     serviceBusConnectionString: serviceBus.outputs.connectionString
     subnetId: networking.outputs.functionAppSubnetId
     keyVaultName: keyVault.outputs.keyVaultName
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
   }
 }
 

--- a/infra/modules/functionapp.bicep
+++ b/infra/modules/functionapp.bicep
@@ -31,6 +31,9 @@ param subnetId string
 @description('Key Vault name for secret references')
 param keyVaultName string
 
+@description('Log Analytics Workspace ID for diagnostics')
+param logAnalyticsWorkspaceId string
+
 // ============================================================================
 // Storage Account for Function App
 // ============================================================================
@@ -149,6 +152,7 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
   scope: functionApp
   name: '${functionAppName}-diag'
   properties: {
+    workspaceId: logAnalyticsWorkspaceId
     logs: [
       {
         categoryGroup: 'allLogs'

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -21,6 +21,9 @@ param vnetId string
 @description('Subnet ID for private endpoint')
 param privateEndpointSubnetId string
 
+@description('Log Analytics Workspace ID for diagnostics')
+param logAnalyticsWorkspaceId string
+
 // ============================================================================
 // Key Vault with Enterprise Security
 // ============================================================================
@@ -107,6 +110,7 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
   scope: keyVault
   name: '${keyVaultName}-diag'
   properties: {
+    workspaceId: logAnalyticsWorkspaceId
     logs: [
       {
         categoryGroup: 'allLogs'

--- a/infra/modules/servicebus.bicep
+++ b/infra/modules/servicebus.bicep
@@ -21,6 +21,9 @@ param vnetId string
 @description('Subnet ID for private endpoint')
 param privateEndpointSubnetId string
 
+@description('Log Analytics Workspace ID for diagnostics')
+param logAnalyticsWorkspaceId string
+
 // ============================================================================
 // Service Bus Namespace - Enterprise Service Hub
 // ============================================================================
@@ -163,6 +166,7 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
   scope: serviceBus
   name: '${serviceBusName}-diag'
   properties: {
+    workspaceId: logAnalyticsWorkspaceId
     logs: [
       {
         categoryGroup: 'allLogs'


### PR DESCRIPTION
## Root Cause
Diagnostic settings on Key Vault, Service Bus, and Function App were missing a \workspaceId\ (Log Analytics data sink). ARM requires at least one sink — this caused:
\\\
BadRequest: At least one data sink needs to be specified.
\\\

## Fix
- Added \logAnalyticsWorkspaceId\ parameter to \keyvault.bicep\, \servicebus.bicep\, and \unctionapp.bicep\
- Set \workspaceId\ on all three diagnostic settings resources
- Wired parameter from \monitoring.outputs.logAnalyticsWorkspaceId\ in \main.bicep\
- Added \infra/main.json\ (ARM compilation output) to \.gitignore\

## ADO Work Items
- Related [AB#29](https://dev.azure.com/ncheruvu0468/78663987-57a0-4f1d-b5a0-8d9ac2417cc1/_workitems/edit/29)

## Validation
- \z bicep build\ passes with zero warnings