### PR TITLE
fix: notation trust policy wildcard in CD pipeline AB#29

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,13 +116,22 @@ jobs:
         run: |
           # Create trust policy for downstream verification
           mkdir -p ./notation-config
-          cat > ./notation-config/trustpolicy.json << 'EOF'
+          cat > ./notation-config/trustpolicy.json << EOF
           {
             "version": "1.0",
             "trustPolicies": [
               {
-                "name": "ssdlc-demo-images",
-                "registryScopes": [ "${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/*" ],
+                "name": "ssdlc-containerapp",
+                "registryScopes": [ "${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/containerapp" ],
+                "signatureVerification": {
+                  "level": "strict"
+                },
+                "trustStores": [ "ca:ssdlc-demo-signing-key" ],
+                "trustedIdentities": [ "*" ]
+              },
+              {
+                "name": "ssdlc-pythonapi",
+                "registryScopes": [ "${{ env.ACR_NAME }}.azurecr.io/ssdlcdemo/pythonapi" ],
                 "signatureVerification": {
                   "level": "strict"
                 },


### PR DESCRIPTION
Fixes Notation trust policy error in CD pipeline. The wildcard \*\ in \egistryScopes\ is not valid — Notation requires fully qualified repository paths. Changed to two explicit policies for \containerapp\ and \pythonapi\ repositories.

[AB#29](https://dev.azure.com/ncheruvu0468/78663987-57a0-4f1d-b5a0-8d9ac2417cc1/_workitems/edit/29)