### PR TITLE
feat: custom runner image builds (Ubuntu/Windows) + self-hosted ACI workflows

### DIFF
--- a/.github/workflows/runner-aci-selfhosted.yml
+++ b/.github/workflows/runner-aci-selfhosted.yml
@@ -1,0 +1,131 @@
+# ==============================================================================
+# Scenario 2: Self-Hosted Runner on Azure Container Instances (ACI)
+# Demonstrates using ACI-based self-hosted runners for GitHub Actions
+# Requires: ACI runner deployed via scripts/setup-aci-github-runner.ps1
+# ==============================================================================
+name: "Runner Test - ACI Self-Hosted"
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_on_selfhosted:
+        description: "Run on self-hosted ACI runner?"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  DOTNET_VERSION: "8.0.x"
+
+jobs:
+  # ── Test on ACI Self-Hosted Runner ─────────────────────────────
+  aci-runner-test:
+    name: "Build on ACI Self-Hosted Runner"
+    runs-on: [self-hosted, aci, linux]
+    if: ${{ inputs.run_on_selfhosted }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runner diagnostics
+        run: |
+          echo "=== Self-Hosted ACI Runner Information ==="
+          echo "Runner Name: ${{ runner.name }}"
+          echo "Runner OS: ${{ runner.os }}"
+          echo "Runner Arch: ${{ runner.arch }}"
+          echo ""
+          echo "=== Hardware Specs ==="
+          nproc
+          free -h
+          df -h /
+          echo ""
+          echo "=== Container Metadata ==="
+          cat /proc/self/cgroup 2>/dev/null | head -5 || true
+          echo ""
+          echo "=== Network (should be Azure IP) ==="
+          curl -s ifconfig.me || true
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build .NET solution
+        run: |
+          echo "=== Building on ACI self-hosted runner ==="
+          time dotnet restore SsdlcDemo.sln
+          time dotnet build SsdlcDemo.sln --configuration Release --no-restore
+
+      - name: Run tests
+        run: |
+          time dotnet test SsdlcDemo.sln --configuration Release --no-build --verbosity normal
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify Azure connectivity from runner
+        run: |
+          echo "=== Azure Context (proves runner can reach Azure via OIDC) ==="
+          az account show --query "{subscription:name, tenantId:tenantId}" -o table
+          az group list --query "[?tags.Project=='ssdlc-demo'].{Name:name, Location:location}" -o table
+
+      - name: Summary
+        run: |
+          echo "## ACI Self-Hosted Runner Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner Name | \`${{ runner.name }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner OS | \`${{ runner.os }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| CPUs | \`$(nproc)\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Memory | \`$(free -h | awk '/^Mem:/{print $2}')\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Azure Connected | Yes (OIDC) |" >> $GITHUB_STEP_SUMMARY
+
+  # ── Comparison: Same job on GitHub-hosted for baseline ─────────
+  github-hosted-baseline:
+    name: "Baseline on GitHub-hosted (ubuntu-latest)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runner diagnostics
+        run: |
+          echo "=== GitHub-Hosted Baseline ==="
+          echo "Runner Name: ${{ runner.name }}"
+          echo "CPUs: $(nproc)"
+          echo "Memory: $(free -h | awk '/^Mem:/{print $2}')"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build .NET solution
+        run: |
+          time dotnet restore SsdlcDemo.sln
+          time dotnet build SsdlcDemo.sln --configuration Release --no-restore
+
+      - name: Run tests
+        run: |
+          time dotnet test SsdlcDemo.sln --configuration Release --no-build --verbosity normal
+
+      - name: Summary
+        run: |
+          echo "## GitHub-Hosted Baseline Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner Label | \`ubuntu-latest\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| CPUs | \`$(nproc)\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Memory | \`$(free -h | awk '/^Mem:/{print $2}')\` |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/runner-build-images.yml
+++ b/.github/workflows/runner-build-images.yml
@@ -1,0 +1,240 @@
+# ==============================================================================
+# Build Custom Runner Images — Ubuntu & Windows
+# Builds custom GitHub Actions self-hosted runner images and pushes to ACR
+# Triggers: manual dispatch, or on changes to runners/ directory
+# ==============================================================================
+name: "Build Runner Images"
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_ubuntu:
+        description: "Build Ubuntu runner image"
+        required: true
+        default: true
+        type: boolean
+      build_windows:
+        description: "Build Windows runner image"
+        required: true
+        default: true
+        type: boolean
+      runner_version:
+        description: "GitHub Actions runner version"
+        required: false
+        default: "2.321.0"
+        type: string
+  push:
+    branches: [main, develop]
+    paths:
+      - "runners/**"
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  ACR_NAME: acrssdlcdemo
+  RUNNER_VERSION: ${{ inputs.runner_version || '2.321.0' }}
+
+jobs:
+  # ── Build Ubuntu Runner Image ──────────────────────────────────
+  build-ubuntu:
+    name: "Build Ubuntu Runner Image"
+    runs-on: ubuntu-latest
+    if: ${{ inputs.build_ubuntu != false }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build & push Ubuntu image to ACR
+        run: |
+          echo "=== Building Ubuntu runner image ==="
+          echo "  ACR: ${{ env.ACR_NAME }}.azurecr.io"
+          echo "  Tag: github-runner-ubuntu:${{ github.sha }}"
+          echo "  Runner Version: ${{ env.RUNNER_VERSION }}"
+
+          az acr build \
+            --registry ${{ env.ACR_NAME }} \
+            --image github-runner-ubuntu:${{ github.sha }} \
+            --image github-runner-ubuntu:latest \
+            --build-arg RUNNER_VERSION=${{ env.RUNNER_VERSION }} \
+            --file runners/ubuntu/Dockerfile \
+            --no-wait \
+            runners/ubuntu/
+
+      - name: Wait for ACR build to complete
+        run: |
+          echo "=== Waiting for ACR build task ==="
+          # Poll for the latest run to complete
+          for i in $(seq 1 30); do
+            STATUS=$(az acr task list-runs \
+              --registry ${{ env.ACR_NAME }} \
+              --top 1 \
+              --query "[0].status" -o tsv 2>/dev/null || echo "Unknown")
+
+            echo "  Attempt $i/30 — Status: $STATUS"
+
+            if [ "$STATUS" = "Succeeded" ]; then
+              echo "  Ubuntu image build succeeded!"
+              break
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Error" ]; then
+              echo "  Ubuntu image build FAILED!"
+              az acr task logs --registry ${{ env.ACR_NAME }} --run-id $(az acr task list-runs --registry ${{ env.ACR_NAME }} --top 1 --query "[0].runId" -o tsv) || true
+              exit 1
+            fi
+
+            sleep 20
+          done
+
+      - name: Verify Ubuntu image in ACR
+        run: |
+          echo "=== Verifying image ==="
+          az acr repository show-tags \
+            --name ${{ env.ACR_NAME }} \
+            --repository github-runner-ubuntu \
+            --orderby time_desc \
+            --top 5 \
+            -o table
+
+      - name: Summary
+        run: |
+          echo "## Ubuntu Runner Image Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | \`${{ env.ACR_NAME }}.azurecr.io/github-runner-ubuntu:${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner Version | \`${{ env.RUNNER_VERSION }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Base OS | Ubuntu 22.04 |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tools | .NET 8, Python 3.12, Node 20, Azure CLI, Docker CLI |" >> $GITHUB_STEP_SUMMARY
+
+  # ── Build Windows Runner Image ─────────────────────────────────
+  build-windows:
+    name: "Build Windows Runner Image"
+    runs-on: ubuntu-latest
+    if: ${{ inputs.build_windows != false }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build & push Windows image to ACR
+        run: |
+          echo "=== Building Windows runner image ==="
+          echo "  ACR: ${{ env.ACR_NAME }}.azurecr.io"
+          echo "  Tag: github-runner-windows:${{ github.sha }}"
+          echo "  Runner Version: ${{ env.RUNNER_VERSION }}"
+
+          az acr build \
+            --registry ${{ env.ACR_NAME }} \
+            --image github-runner-windows:${{ github.sha }} \
+            --image github-runner-windows:latest \
+            --platform windows \
+            --build-arg RUNNER_VERSION=${{ env.RUNNER_VERSION }} \
+            --file runners/windows/Dockerfile \
+            --no-wait \
+            runners/windows/
+
+      - name: Wait for ACR build to complete
+        run: |
+          echo "=== Waiting for ACR build task ==="
+          for i in $(seq 1  45); do
+            STATUS=$(az acr task list-runs \
+              --registry ${{ env.ACR_NAME }} \
+              --top 1 \
+              --query "[0].status" -o tsv 2>/dev/null || echo "Unknown")
+
+            echo "  Attempt $i/45 — Status: $STATUS"
+
+            if [ "$STATUS" = "Succeeded" ]; then
+              echo "  Windows image build succeeded!"
+              break
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Error" ]; then
+              echo "  Windows image build FAILED!"
+              az acr task logs --registry ${{ env.ACR_NAME }} --run-id $(az acr task list-runs --registry ${{ env.ACR_NAME }} --top 1 --query "[0].runId" -o tsv) || true
+              exit 1
+            fi
+
+            sleep 30
+          done
+
+      - name: Verify Windows image in ACR
+        run: |
+          echo "=== Verifying image ==="
+          az acr repository show-tags \
+            --name ${{ env.ACR_NAME }} \
+            --repository github-runner-windows \
+            --orderby time_desc \
+            --top 5 \
+            -o table
+
+      - name: Summary
+        run: |
+          echo "## Windows Runner Image Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | \`${{ env.ACR_NAME }}.azurecr.io/github-runner-windows:${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner Version | \`${{ env.RUNNER_VERSION }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Base OS | Windows Server 2022 LTSC |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tools | .NET 8, Node 20, Azure CLI, Git |" >> $GITHUB_STEP_SUMMARY
+
+  # ── Post-build: List all runner images ─────────────────────────
+  verify-images:
+    name: "Verify All Runner Images"
+    runs-on: ubuntu-latest
+    needs: [build-ubuntu, build-windows]
+    if: always()
+    steps:
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: List runner images in ACR
+        run: |
+          echo "=== All runner images in ACR ==="
+          echo ""
+          echo "--- Ubuntu Runner ---"
+          az acr repository show-tags \
+            --name ${{ env.ACR_NAME }} \
+            --repository github-runner-ubuntu \
+            --orderby time_desc --top 5 -o table 2>/dev/null || echo "  (no ubuntu images yet)"
+          echo ""
+          echo "--- Windows Runner ---"
+          az acr repository show-tags \
+            --name ${{ env.ACR_NAME }} \
+            --repository github-runner-windows \
+            --orderby time_desc --top 5 -o table 2>/dev/null || echo "  (no windows images yet)"
+
+      - name: Summary
+        run: |
+          echo "## Runner Image Inventory" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | Registry | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| github-runner-ubuntu | ${{ env.ACR_NAME }}.azurecr.io | ${{ needs.build-ubuntu.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| github-runner-windows | ${{ env.ACR_NAME }}.azurecr.io | ${{ needs.build-windows.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Usage" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "# Deploy Ubuntu runner to ACI:" >> $GITHUB_STEP_SUMMARY
+          echo "./scripts/setup-aci-github-runner.ps1 \\" >> $GITHUB_STEP_SUMMARY
+          echo "    -ContainerImage ${{ env.ACR_NAME }}.azurecr.io/github-runner-ubuntu:latest" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/runner-larger-hosted.yml
+++ b/.github/workflows/runner-larger-hosted.yml
@@ -1,0 +1,120 @@
+# ==============================================================================
+# Scenario 1: GitHub-Hosted Larger Runners
+# Demonstrates using configurable GitHub-hosted runners with larger specs
+# Requires: Larger runner configured in repo/org settings (Settings > Actions > Runners)
+# ==============================================================================
+name: "Runner Test - GitHub Larger Hosted"
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_label:
+        description: "Larger runner label (configured in Settings > Actions > Runners)"
+        required: false
+        default: "ubuntu-latest-4-cores"
+        type: choice
+        options:
+          - ubuntu-latest-4-cores
+          - ubuntu-latest-8-cores
+          - ubuntu-latest-16-cores
+          - windows-latest-8-cores
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Test on GitHub Larger Runner ───────────────────────────────
+  larger-runner-test:
+    name: "Build on Larger Runner (${{ inputs.runner_label }})"
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runner diagnostics
+        run: |
+          echo "=== Runner Information ==="
+          echo "Runner Name: ${{ runner.name }}"
+          echo "Runner OS: ${{ runner.os }}"
+          echo "Runner Arch: ${{ runner.arch }}"
+          echo ""
+          echo "=== Hardware Specs ==="
+          nproc || echo "nproc not available"
+          free -h || echo "free not available"
+          df -h / || echo "df not available"
+          cat /proc/cpuinfo | grep "model name" | head -1 || true
+          echo ""
+          echo "=== Network ==="
+          curl -s ifconfig.me || true
+        shell: bash
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build .NET solution
+        run: |
+          echo "=== Building on larger runner to demonstrate speed ==="
+          time dotnet restore SsdlcDemo.sln
+          time dotnet build SsdlcDemo.sln --configuration Release --no-restore
+        shell: bash
+
+      - name: Run tests
+        run: |
+          time dotnet test SsdlcDemo.sln --configuration Release --no-build --verbosity normal
+        shell: bash
+
+      - name: Summary
+        run: |
+          echo "## Larger Runner Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner Label | \`${{ inputs.runner_label }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner Name | \`${{ runner.name }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner OS | \`${{ runner.os }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| CPUs | \`$(nproc 2>/dev/null || echo N/A)\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Memory | \`$(free -h 2>/dev/null | awk '/^Mem:/{print $2}' || echo N/A)\` |" >> $GITHUB_STEP_SUMMARY
+        shell: bash
+
+  # ── Fallback: Test on standard runner for comparison ───────────
+  standard-runner-baseline:
+    name: "Baseline on ubuntu-latest (2 cores)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runner diagnostics
+        run: |
+          echo "=== Baseline Runner Information ==="
+          echo "Runner Name: ${{ runner.name }}"
+          echo "CPUs: $(nproc)"
+          echo "Memory: $(free -h | awk '/^Mem:/{print $2}')"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build .NET solution
+        run: |
+          time dotnet restore SsdlcDemo.sln
+          time dotnet build SsdlcDemo.sln --configuration Release --no-restore
+
+      - name: Run tests
+        run: |
+          time dotnet test SsdlcDemo.sln --configuration Release --no-build --verbosity normal
+
+      - name: Summary
+        run: |
+          echo "## Standard Runner Baseline Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Runner Label | \`ubuntu-latest\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| CPUs | \`$(nproc)\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Memory | \`$(free -h | awk '/^Mem:/{print $2}')\` |" >> $GITHUB_STEP_SUMMARY

--- a/runners/ubuntu/Dockerfile
+++ b/runners/ubuntu/Dockerfile
@@ -1,0 +1,81 @@
+# ==============================================================================
+# Custom GitHub Actions Self-Hosted Runner — Ubuntu 22.04
+# Pre-installed: .NET 8, Python 3.12, Node 20, Azure CLI, Docker CLI
+# Security: non-root runner user
+# ==============================================================================
+FROM ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── OS packages & dependencies ───────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    unzip \
+    zip \
+    wget \
+    apt-transport-https \
+    software-properties-common \
+    gnupg \
+    lsb-release \
+    sudo \
+    build-essential \
+    libicu-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── .NET 8 SDK ───────────────────────────────────────────────────
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin \
+    --channel 8.0 --install-dir /usr/share/dotnet
+ENV DOTNET_ROOT=/usr/share/dotnet
+ENV PATH="${DOTNET_ROOT}:${PATH}"
+
+# ── Python 3.12 ──────────────────────────────────────────────────
+RUN add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 python3.12-venv python3.12-dev python3-pip && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── Node.js 20 LTS ──────────────────────────────────────────────
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── Azure CLI ────────────────────────────────────────────────────
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── Docker CLI (for container builds inside runner) ──────────────
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && apt-get install -y --no-install-recommends docker-ce-cli && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── GitHub Actions Runner ────────────────────────────────────────
+ARG RUNNER_VERSION=2.321.0
+ARG RUNNER_ARCH=x64
+
+RUN mkdir -p /home/runner && \
+    curl -sSL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz" \
+    | tar -xz -C /home/runner
+
+# ── Security: non-root user ─────────────────────────────────────
+RUN useradd -m -d /home/runner -s /bin/bash runner && \
+    chown -R runner:runner /home/runner && \
+    echo "runner ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+WORKDIR /home/runner
+USER runner
+
+# ── Entrypoint: configure and run ────────────────────────────────
+COPY entrypoint.sh /home/runner/entrypoint.sh
+USER root
+RUN chmod +x /home/runner/entrypoint.sh
+USER runner
+
+ENTRYPOINT ["/home/runner/entrypoint.sh"]

--- a/runners/ubuntu/entrypoint.sh
+++ b/runners/ubuntu/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# ==============================================================================
+# Entrypoint for GitHub Actions self-hosted runner container
+# Registers the runner, starts it, and deregisters on exit
+# ==============================================================================
+
+RUNNER_NAME="${RUNNER_NAME:-$(hostname)}"
+RUNNER_WORKDIR="${RUNNER_WORKDIR:-/home/runner/_work}"
+RUNNER_LABELS="${RUNNER_LABELS:-self-hosted,aci,linux,custom}"
+RUNNER_GROUP="${RUNNER_GROUP:-Default}"
+
+# Validate required environment variables
+if [ -z "${GITHUB_URL:-}" ]; then
+    echo "ERROR: GITHUB_URL is required (e.g., https://github.com/org/repo)"
+    exit 1
+fi
+
+if [ -z "${RUNNER_TOKEN:-}" ]; then
+    echo "ERROR: RUNNER_TOKEN is required (registration token from GitHub API)"
+    exit 1
+fi
+
+echo "=== Configuring GitHub Actions Runner ==="
+echo "  Name:   ${RUNNER_NAME}"
+echo "  Labels: ${RUNNER_LABELS}"
+echo "  URL:    ${GITHUB_URL}"
+echo "  Work:   ${RUNNER_WORKDIR}"
+
+# Configure the runner
+./config.sh \
+    --url "${GITHUB_URL}" \
+    --token "${RUNNER_TOKEN}" \
+    --name "${RUNNER_NAME}" \
+    --labels "${RUNNER_LABELS}" \
+    --work "${RUNNER_WORKDIR}" \
+    --unattended \
+    --replace
+
+# Deregister on exit (graceful cleanup)
+cleanup() {
+    echo "=== Removing runner registration ==="
+    ./config.sh remove --token "${RUNNER_TOKEN}" || true
+}
+trap cleanup EXIT SIGTERM SIGINT
+
+echo "=== Starting runner ==="
+./run.sh

--- a/runners/windows/Dockerfile
+++ b/runners/windows/Dockerfile
@@ -1,0 +1,61 @@
+# escape=`
+# ==============================================================================
+# Custom GitHub Actions Self-Hosted Runner — Windows Server 2022
+# Pre-installed: .NET 8, Node 20, Azure CLI, Git, Docker CLI
+# Security: non-admin ContainerUser
+# ==============================================================================
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue';"]
+
+# ── Metadata ─────────────────────────────────────────────────────
+LABEL maintainer="ssdlc-demo" `
+      description="Custom GitHub Actions runner for Windows" `
+      os="windows-ltsc2022"
+
+# ── Git ──────────────────────────────────────────────────────────
+RUN $gitUrl = 'https://github.com/git-for-windows/git/releases/download/v2.44.0.windows.1/MinGit-2.44.0-64-bit.zip'; `
+    Invoke-WebRequest -Uri $gitUrl -OutFile git.zip; `
+    Expand-Archive git.zip -DestinationPath C:\git; `
+    Remove-Item git.zip; `
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\git\cmd', 'Machine')
+
+# ── .NET 8 SDK ───────────────────────────────────────────────────
+RUN Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1; `
+    .\dotnet-install.ps1 -Channel 8.0 -InstallDir 'C:\dotnet'; `
+    Remove-Item dotnet-install.ps1; `
+    [Environment]::SetEnvironmentVariable('DOTNET_ROOT', 'C:\dotnet', 'Machine'); `
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\dotnet', 'Machine')
+
+# ── Node.js 20 LTS ──────────────────────────────────────────────
+RUN $nodeUrl = 'https://nodejs.org/dist/v20.11.1/node-v20.11.1-win-x64.zip'; `
+    Invoke-WebRequest -Uri $nodeUrl -OutFile node.zip; `
+    Expand-Archive node.zip -DestinationPath C:\; `
+    Rename-Item 'C:\node-v20.11.1-win-x64' 'C:\nodejs'; `
+    Remove-Item node.zip; `
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\nodejs', 'Machine')
+
+# ── Azure CLI ────────────────────────────────────────────────────
+RUN $azUrl = 'https://aka.ms/installazurecliwindowsx64'; `
+    Invoke-WebRequest -Uri $azUrl -OutFile az-cli.msi; `
+    Start-Process msiexec.exe -ArgumentList '/i', 'az-cli.msi', '/quiet', '/norestart' -Wait; `
+    Remove-Item az-cli.msi
+
+# ── GitHub Actions Runner ────────────────────────────────────────
+ARG RUNNER_VERSION=2.321.0
+
+RUN $runnerUrl = \"https://github.com/actions/runner/releases/download/v$env:RUNNER_VERSION/actions-runner-win-x64-$env:RUNNER_VERSION.zip\"; `
+    Invoke-WebRequest -Uri $runnerUrl -OutFile runner.zip; `
+    New-Item -ItemType Directory -Path C:\runner -Force; `
+    Expand-Archive runner.zip -DestinationPath C:\runner; `
+    Remove-Item runner.zip
+
+WORKDIR C:\runner
+
+# ── Entrypoint ───────────────────────────────────────────────────
+COPY entrypoint.ps1 C:\runner\entrypoint.ps1
+
+# Security: use ContainerUser (non-admin)
+USER ContainerUser
+
+ENTRYPOINT ["powershell", "-File", "C:\\runner\\entrypoint.ps1"]

--- a/runners/windows/entrypoint.ps1
+++ b/runners/windows/entrypoint.ps1
@@ -1,0 +1,44 @@
+# ==============================================================================
+# Entrypoint for GitHub Actions self-hosted runner (Windows container)
+# Registers the runner, starts it, and deregisters on exit
+# ==============================================================================
+$ErrorActionPreference = "Stop"
+
+$RunnerName   = if ($env:RUNNER_NAME)   { $env:RUNNER_NAME }   else { $env:COMPUTERNAME }
+$RunnerWork   = if ($env:RUNNER_WORKDIR){ $env:RUNNER_WORKDIR } else { "C:\runner\_work" }
+$RunnerLabels = if ($env:RUNNER_LABELS) { $env:RUNNER_LABELS } else { "self-hosted,aci,windows,custom" }
+$RunnerGroup  = if ($env:RUNNER_GROUP)  { $env:RUNNER_GROUP }  else { "Default" }
+
+# Validate required environment variables
+if (-not $env:GITHUB_URL) {
+    Write-Error "GITHUB_URL is required (e.g., https://github.com/org/repo)"
+    exit 1
+}
+if (-not $env:RUNNER_TOKEN) {
+    Write-Error "RUNNER_TOKEN is required (registration token from GitHub API)"
+    exit 1
+}
+
+Write-Host "=== Configuring GitHub Actions Runner ==="
+Write-Host "  Name:   $RunnerName"
+Write-Host "  Labels: $RunnerLabels"
+Write-Host "  URL:    $env:GITHUB_URL"
+Write-Host "  Work:   $RunnerWork"
+
+# Configure the runner
+& .\config.cmd `
+    --url $env:GITHUB_URL `
+    --token $env:RUNNER_TOKEN `
+    --name $RunnerName `
+    --labels $RunnerLabels `
+    --work $RunnerWork `
+    --unattended `
+    --replace
+
+# Start the runner (blocks until terminated)
+Write-Host "=== Starting runner ==="
+& .\run.cmd
+
+# Cleanup on exit
+Write-Host "=== Removing runner registration ==="
+& .\config.cmd remove --token $env:RUNNER_TOKEN

--- a/scripts/setup-aci-github-runner.ps1
+++ b/scripts/setup-aci-github-runner.ps1
@@ -1,0 +1,198 @@
+<#
+.SYNOPSIS
+    Sets up a GitHub Actions self-hosted runner on Azure Container Instances (ACI).
+    
+.DESCRIPTION
+    Creates an ACI container group running the GitHub Actions runner agent.
+    Uses your existing OIDC SP for Azure authentication.
+    Since subscription has zero VM quotas, ACI is used instead of VMSS.
+
+.PARAMETER GitHubOrg
+    GitHub organization name
+
+.PARAMETER GitHubRepo
+    GitHub repository name
+
+.PARAMETER GitHubPAT
+    GitHub Personal Access Token with 'repo' and 'admin:org' scopes
+    (needed to register runners). Store in Key Vault for production use.
+
+.PARAMETER ResourceGroupName
+    Azure resource group to deploy ACI into
+
+.PARAMETER Location
+    Azure region (default: canadacentral)
+
+.PARAMETER RunnerName
+    Name for the runner instance
+
+.PARAMETER ContainerCpu
+    CPU cores for the container (default: 2)
+
+.PARAMETER ContainerMemoryGb
+    Memory in GB for the container (default: 4)
+
+.EXAMPLE
+    ./setup-aci-github-runner.ps1 `
+        -GitHubOrg "myorg" `
+        -GitHubRepo "az-github-ssdlc-demo" `
+        -GitHubPAT $env:GITHUB_PAT `
+        -ResourceGroupName "rg-ssdlc-runners" `
+        -Location "canadacentral"
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$GitHubOrg,
+
+    [Parameter(Mandatory = $true)]
+    [string]$GitHubRepo,
+
+    [Parameter(Mandatory = $true)]
+    [string]$GitHubPAT,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ResourceGroupName = "rg-ssdlc-runners-dev",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Location = "canadacentral",
+
+    [Parameter(Mandatory = $false)]
+    [string]$RunnerName = "aci-runner-01",
+
+    [Parameter(Mandatory = $false)]
+    [int]$ContainerCpu = 2,
+
+    [Parameter(Mandatory = $false)]
+    [int]$ContainerMemoryGb = 4,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ContainerImage = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== GitHub Actions Self-Hosted Runner on ACI ===" -ForegroundColor Cyan
+
+# ── Step 1: Get runner registration token ────────────────────────
+Write-Host "`n[1/5] Getting runner registration token..." -ForegroundColor Yellow
+
+$tokenResponse = Invoke-RestMethod `
+    -Uri "https://api.github.com/repos/$GitHubOrg/$GitHubRepo/actions/runners/registration-token" `
+    -Method Post `
+    -Headers @{
+        Authorization = "Bearer $GitHubPAT"
+        Accept        = "application/vnd.github+json"
+        "X-GitHub-Api-Version" = "2022-11-28"
+    }
+
+$registrationToken = $tokenResponse.token
+Write-Host "  Registration token obtained (expires in 1 hour)" -ForegroundColor Green
+
+# ── Step 2: Ensure resource group exists ─────────────────────────
+Write-Host "`n[2/5] Ensuring resource group '$ResourceGroupName' exists..." -ForegroundColor Yellow
+
+$rgExists = az group exists --name $ResourceGroupName | ConvertFrom-Json
+if (-not $rgExists) {
+    az group create --name $ResourceGroupName --location $Location --tags Environment=dev Project=ssdlc-demo ManagedBy=script | Out-Null
+    Write-Host "  Created resource group" -ForegroundColor Green
+} else {
+    Write-Host "  Resource group already exists" -ForegroundColor Green
+}
+
+# ── Step 3: Create ACI container group ───────────────────────────
+Write-Host "`n[3/5] Deploying ACI container group '$RunnerName'..." -ForegroundColor Yellow
+
+# Using the official GitHub runner image from ghcr.io
+# For production, use custom image from ACR (built by runner-build-images.yml)
+if ($ContainerImage) {
+    $containerImageToUse = $ContainerImage
+    Write-Host "  Using custom image: $containerImageToUse" -ForegroundColor Cyan
+} else {
+    $containerImageToUse = "ghcr.io/actions/actions-runner:latest"
+    Write-Host "  Using default image: $containerImageToUse" -ForegroundColor Cyan
+}
+$repoUrl = "https://github.com/$GitHubOrg/$GitHubRepo"
+
+# Check if container already exists and delete it
+$existing = az container show --resource-group $ResourceGroupName --name $RunnerName 2>$null
+if ($existing) {
+    Write-Host "  Deleting existing container..." -ForegroundColor DarkYellow
+    az container delete --resource-group $ResourceGroupName --name $RunnerName --yes | Out-Null
+}
+
+# Deploy ACI with runner configuration
+az container create `
+    --resource-group $ResourceGroupName `
+    --name $RunnerName `
+    --image $containerImageToUse `
+    --cpu $ContainerCpu `
+    --memory $ContainerMemoryGb `
+    --os-type Linux `
+    --restart-policy Never `
+    --environment-variables `
+        RUNNER_NAME=$RunnerName `
+        RUNNER_WORKDIR="/home/runner/_work" `
+        GITHUB_URL=$repoUrl `
+        RUNNER_TOKEN=$registrationToken `
+        RUNNER_LABELS="self-hosted,aci,linux" `
+        RUNNER_GROUP="Default" `
+    --command-line "/bin/bash -c './config.sh --url $repoUrl --token $registrationToken --name $RunnerName --labels self-hosted,aci,linux --unattended --replace && ./run.sh'" `
+    --tags Environment=dev Project=ssdlc-demo ManagedBy=script SecurityLevel=standard `
+    --location $Location | Out-Null
+
+Write-Host "  ACI container deployed successfully" -ForegroundColor Green
+
+# ── Step 4: Verify runner is online ──────────────────────────────
+Write-Host "`n[4/5] Waiting for runner to register..." -ForegroundColor Yellow
+
+$maxAttempts = 12
+$attempt = 0
+$runnerOnline = $false
+
+while ($attempt -lt $maxAttempts -and -not $runnerOnline) {
+    Start-Sleep -Seconds 10
+    $attempt++
+
+    $runners = Invoke-RestMethod `
+        -Uri "https://api.github.com/repos/$GitHubOrg/$GitHubRepo/actions/runners" `
+        -Headers @{
+            Authorization = "Bearer $GitHubPAT"
+            Accept        = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+        }
+
+    $ourRunner = $runners.runners | Where-Object { $_.name -eq $RunnerName }
+    if ($ourRunner -and $ourRunner.status -eq "online") {
+        $runnerOnline = $true
+        Write-Host "  Runner '$RunnerName' is ONLINE (ID: $($ourRunner.id))" -ForegroundColor Green
+    } else {
+        Write-Host "  Attempt $attempt/$maxAttempts - waiting..." -ForegroundColor DarkGray
+    }
+}
+
+if (-not $runnerOnline) {
+    Write-Host "  WARNING: Runner not online yet. Check ACI logs:" -ForegroundColor Red
+    Write-Host "  az container logs --resource-group $ResourceGroupName --name $RunnerName" -ForegroundColor DarkYellow
+}
+
+# ── Step 5: Show summary ─────────────────────────────────────────
+Write-Host "`n[5/5] Summary" -ForegroundColor Yellow
+Write-Host "  ┌──────────────────────────────────────────────────────────" -ForegroundColor DarkGray
+Write-Host "  │ Runner Name:    $RunnerName" -ForegroundColor White
+Write-Host "  │ Labels:         self-hosted, aci, linux" -ForegroundColor White
+Write-Host "  │ Resource Group: $ResourceGroupName" -ForegroundColor White
+Write-Host "  │ Container CPU:  $ContainerCpu cores" -ForegroundColor White
+Write-Host "  │ Container RAM:  ${ContainerMemoryGb} GB" -ForegroundColor White
+Write-Host "  │ Location:       $Location" -ForegroundColor White
+Write-Host "  │ Image:          $containerImageToUse" -ForegroundColor White
+Write-Host "  └──────────────────────────────────────────────────────────" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "  Use in workflows with: runs-on: [self-hosted, aci, linux]" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Useful commands:" -ForegroundColor DarkGray
+Write-Host "    az container logs -g $ResourceGroupName -n $RunnerName" -ForegroundColor DarkGray
+Write-Host "    az container show -g $ResourceGroupName -n $RunnerName --query 'instanceView.state'" -ForegroundColor DarkGray
+Write-Host "    az container delete -g $ResourceGroupName -n $RunnerName --yes  # Cleanup" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary
Adds infrastructure for building custom GitHub Actions self-hosted runner images and testing both larger-hosted and ACI-based runner scenarios.

### Files Added
- **runners/ubuntu/Dockerfile** — Custom Ubuntu 22.04 runner (.NET 8, Python 3.12, Node 20, Azure CLI)
- **runners/windows/Dockerfile** — Custom Windows Server 2022 runner (.NET 8, Node 20, Azure CLI)
- **.github/workflows/runner-build-images.yml** — Builds both OS images, pushes to ACR
- **.github/workflows/runner-larger-hosted.yml** — Tests GitHub larger runners vs standard
- **.github/workflows/runner-aci-selfhosted.yml** — Tests ACI self-hosted runners
- **scripts/setup-aci-github-runner.ps1** — Deploys ACI runner containers

### Security Checklist
- [x] Non-root containers (USER runner / ContainerUser)
- [x] No hardcoded secrets (uses OIDC + env vars)
- [x] RBAC via existing OIDC SP
- [x] Runner tokens are ephemeral (1hr TTL)